### PR TITLE
[UI]: wrap movie logo on detail screen with a linear gradient

### DIFF
--- a/packages/app/components/av.tsx
+++ b/packages/app/components/av.tsx
@@ -9,7 +9,10 @@ import { useAsyncStorage } from '@react-native-async-storage/async-storage'
 export type ProgressInfo = {
     positionMillis: number
     uri: string
-    percentCompleted?: number
+    viewingProgress?: {
+        timeLeft: number
+        percentageCompleted: number
+    }
     completed: boolean
     episode?: number
     season?: number
@@ -63,10 +66,14 @@ export const VideoPlayer = (props: {
                 // Update your UI for the playing state
                 updateProgress({
                     positionMillis: status.positionMillis,
-                    //percentage in a range ong 0-100
-                    percentCompleted: Math.round(
-                        (status.positionMillis / status.durationMillis!!) * 100
-                    ),
+                    viewingProgress: {
+                        timeLeft:
+                            status.durationMillis!! - status.positionMillis,
+                        percentageCompleted: Math.round(
+                            (status.positionMillis / status.durationMillis!!) *
+                                100
+                        ),
+                    },
                     uri: props.src,
                     completed: false,
                     ...(props.mediaType === 'show' && {
@@ -79,9 +86,14 @@ export const VideoPlayer = (props: {
                 // Update your UI for the paused state
                 updateProgress({
                     positionMillis: status.positionMillis,
-                    percentCompleted: Math.round(
-                        (status.positionMillis / status.durationMillis!!) * 100
-                    ),
+                    viewingProgress: {
+                        timeLeft:
+                            status.durationMillis!! - status.positionMillis,
+                        percentageCompleted: Math.round(
+                            (status.positionMillis / status.durationMillis!!) *
+                                100
+                        ),
+                    },
                     uri: props.src,
                     completed: false,
                     ...(props.mediaType === 'show' && {
@@ -100,7 +112,11 @@ export const VideoPlayer = (props: {
                 // The player has just finished playing and will stop. Maybe you want to play something else?
                 updateProgress({
                     positionMillis: 0,
-                    percentCompleted: 100,
+                    viewingProgress: {
+                        timeLeft:
+                            status.durationMillis!! - status.positionMillis,
+                        percentageCompleted: 100,
+                    },
                     uri: props.src,
                     completed: true,
                     ...(props.mediaType === 'show' && {

--- a/packages/app/components/greeting.tsx
+++ b/packages/app/components/greeting.tsx
@@ -18,7 +18,12 @@ export const SearchHeaderComponent = ({ showNavBar }) => (
 export const LargeSearchHeaderComponent = ({ scrollY }) => (
     <LargeHeader>
         <ScalingView scrollY={scrollY} pb="$0">
-            <H2 fontFamily="System" fontWeight={'bold'} p="$2" pb="$0">
+            <H2
+                style={{ fontFamily: 'System' }}
+                fontWeight={'bold'}
+                p="$2"
+                pb="$0"
+            >
                 Search
             </H2>
         </ScalingView>
@@ -28,7 +33,12 @@ export const LargeSearchHeaderComponent = ({ scrollY }) => (
 export const LargeLibraryHeaderComponent = ({ scrollY }) => (
     <LargeHeader>
         <ScalingView scrollY={scrollY} pb="$0">
-            <H2 fontFamily="System" fontWeight={'bold'} p="$2" pb="$0">
+            <H2
+                style={{ fontFamily: 'System' }}
+                fontWeight={'bold'}
+                p="$2"
+                pb="$0"
+            >
                 Library
             </H2>
         </ScalingView>
@@ -61,7 +71,12 @@ export const Greeting = () => {
 
     return (
         <View style={styles.container}>
-            <H2 fontFamily="System" fontWeight={'bold'} p="$2" pb="$0">
+            <H2
+                style={{ fontFamily: 'System' }}
+                fontWeight={'bold'}
+                p="$2"
+                pb="$0"
+            >
                 {greeting}
             </H2>
             <UserCircle2
@@ -75,6 +90,7 @@ export const Greeting = () => {
             />
             <Sheet
                 modal
+                native
                 animation="medium"
                 open={open}
                 onOpenChange={setOpen}

--- a/packages/app/components/underlined-tab-view.tsx
+++ b/packages/app/components/underlined-tab-view.tsx
@@ -129,8 +129,8 @@ export const DetailedTabView = (props: DetailedTabViewProps) => {
             size="$4"
             flexDirection="column"
             backgroundColor="transparent"
-            borderRadius="$4"
             px="$4"
+            mt="$4"
         >
             <YStack>
                 <AnimatePresence>

--- a/packages/app/components/underlined-tab-view.tsx
+++ b/packages/app/components/underlined-tab-view.tsx
@@ -301,8 +301,6 @@ function MoreDetailsTab({
             <YGroup.Item backgroundColor="$transparent">
                 <ListItem
                     backgroundColor="$transparent"
-                    // hoverTheme
-                    // pressTheme
                     title="Genre"
                     subTitle={genre}
                     icon={null}
@@ -312,8 +310,6 @@ function MoreDetailsTab({
             <YGroup.Item backgroundColor="$transparent">
                 <ListItem
                     backgroundColor="$transparent"
-                    // hoverTheme
-                    // pressTheme
                     title="Director"
                     subTitle={director}
                     icon={null}
@@ -323,8 +319,6 @@ function MoreDetailsTab({
             <YGroup.Item backgroundColor="$transparent">
                 <ListItem
                     backgroundColor="$transparent"
-                    // hoverTheme
-                    // pressTheme
                     title="Starring"
                     subTitle={starring}
                     icon={null}
@@ -334,8 +328,6 @@ function MoreDetailsTab({
             <YGroup.Item backgroundColor="$transparent">
                 <ListItem
                     backgroundColor="$transparent"
-                    // hoverTheme
-                    // pressTheme
                     title="Studio"
                     subTitle={studio}
                     icon={null}
@@ -347,7 +339,9 @@ function MoreDetailsTab({
 }
 
 const SimilarMovies = ({ similarMovies }: { similarMovies: Base[] | null }) => {
-    similarMovies = similarMovies?.slice(0, 10)!!
+    similarMovies = similarMovies?.filter(
+        (item, index) => item.imageUrl !== null && index < 10
+    ) as Base[]
     if (!similarMovies) return
     return (
         <GridView

--- a/packages/app/features/user/detail-screen.tsx
+++ b/packages/app/features/user/detail-screen.tsx
@@ -534,7 +534,6 @@ const Badges = () => {
             borderColor="transparent"
             padding="$2"
             mx="$4"
-            // alignSelf="center"
         >
             {BadgesUrl.map((item, index) => {
                 return (

--- a/packages/app/features/user/detail-screen.tsx
+++ b/packages/app/features/user/detail-screen.tsx
@@ -10,7 +10,7 @@ import {
 import { createParam } from 'solito'
 import { useLink } from 'solito/link'
 import { useMovieData } from 'app/hooks/useMovieData'
-import { Dimensions, ImageBackground, ScrollView, View } from 'react-native'
+import { Dimensions, ImageBackground, ScrollView } from 'react-native'
 import { useAsyncStorage } from '@react-native-async-storage/async-storage'
 import {
     Check,
@@ -37,6 +37,10 @@ import {
     YStack,
 } from 'tamagui'
 import { DetailedTabView } from 'app/components/underlined-tab-view'
+import { LinearGradient } from 'expo-linear-gradient'
+import { StyleSheet } from 'react-native'
+import { View } from 'tamagui'
+
 const { useParam } = createParam<{ id: string; type: string }>()
 
 export function UserDetailScreen() {
@@ -83,13 +87,6 @@ export function UserDetailScreen() {
         console.log('progrssInfo', res)
         setProgress(res)
     }
-
-    const BadgesUrl: Array<string> = [
-        'https://tv.apple.com/assets/badges/MetadataBadge%204K%20OnDark-c90195dae0171c69694b4d7386421ad8.svg',
-        'https://tv.apple.com/assets/badges/MetadataBadge%20AD%20OnDark-4731d380509cdd9c3e59e73cb9dc09d5.svg',
-        'https://tv.apple.com/assets/badges/MetadataBadge%20SDH%20OnDark-45f29ce5e07128bf67d924a31a003cf3.svg',
-        'https://tv.apple.com/assets/badges/MetadataBadge%20CC%20OnDark-7b5b00df263bfee5af843510f708c307.svg',
-    ]
 
     const removeItemFromWishlistStorage = async () => {
         const item = await getItem()
@@ -295,18 +292,11 @@ export function UserDetailScreen() {
                                 </XStack>
                                 {images?.logos[0] !== undefined && (
                                     // @ts-ignore
-                                    <BlurView
-                                        intensity={10}
-                                        tint="dark"
-                                        mt="$10"
-                                        style={{
-                                            width: '100%',
-                                            height: '20%',
-                                            position: 'absolute',
-                                            bottom: 0,
-                                            alignItems: 'center',
-                                            justifyContent: 'center',
-                                        }}
+                                    <LinearGradient
+                                        colors={['black', 'transparent']}
+                                        style={styles.gradient}
+                                        start={{ x: 0, y: 1.0 }}
+                                        end={{ x: 0, y: 0 }}
                                     >
                                         <Image
                                             source={{
@@ -316,14 +306,11 @@ export function UserDetailScreen() {
                                                 }`,
                                             }}
                                             width="100%"
-                                            height={100}
+                                            height={70}
                                             resizeMode="contain"
-                                            bottom={3}
                                             position="absolute"
-
-                                            // px="$8"
                                         />
-                                    </BlurView>
+                                    </LinearGradient>
                                 )}
                             </ImageBackground>
                         </View>
@@ -358,86 +345,13 @@ export function UserDetailScreen() {
                                 progressVal={progress?.percentCompleted}
                             />
                         )}
-                        <ExtraInfo {...movieData} />
-
-                        <XStack
-                            flex={1}
-                            space="$2"
-                            borderWidth={2}
-                            borderColor="transparent"
-                            padding="$2"
-                            alignSelf="center"
-                        >
-                            {BadgesUrl.map((item, index) => {
-                                return (
-                                    <YStack
-                                        alignItems="center"
-                                        padding="$0"
-                                        backgroundColor="$transparent"
-                                        theme={'alt2'}
-                                    >
-                                        <SvgUri
-                                            uri={item}
-                                            style={{ opacity: 0.8 }}
-                                        />
-                                    </YStack>
-                                )
-                            })}
-                        </XStack>
-
-                        <XStack
-                            flex={1}
-                            space="$8"
-                            borderWidth={2}
-                            borderColor="transparent"
-                            padding="$2"
-                            alignSelf="center"
-                        >
-                            <YStack
-                                alignItems="center"
-                                padding="$2"
-                                onPress={() => {
-                                    writeItemToStorage('true')
-                                }}
-                            >
-                                {!wishedlisted ? (
-                                    <Plus size={20} theme="alt1" />
-                                ) : (
-                                    <Check size={20} theme="alt1" />
-                                )}
-
-                                <SizableText
-                                    size="$2"
-                                    theme={'alt1'}
-                                    style={{
-                                        textTransform: 'uppercase',
-                                        fontFamily: 'System',
-                                    }}
-                                >
-                                    Watchlist
-                                </SizableText>
-                            </YStack>
-                            <YStack alignItems="center" padding="$2">
-                                <Download size={20} theme="alt1" />
-                                <SizableText
-                                    size="$2"
-                                    style={{
-                                        textTransform: 'uppercase',
-                                        fontFamily: 'System',
-                                    }}
-                                    theme={'alt1'}
-                                >
-                                    Download
-                                </SizableText>
-                            </YStack>
-                        </XStack>
-                        <Separator px="$4" />
                         <Paragraph
                             m="$4"
                             style={{
                                 fontFamily: 'System',
                             }}
-                            fontSize={18}
+                            fontSize={16}
+                            lineHeight="$1"
                         >
                             {showMore
                                 ? movieData.overview
@@ -454,6 +368,10 @@ export function UserDetailScreen() {
                                 ...{showMore ? 'less' : 'more'}
                             </SizableText>
                         </Paragraph>
+
+                        <ExtraInfo {...movieData} />
+                        <Badges />
+
                         <DetailedTabView
                             movieType={type}
                             movieId={id!!}
@@ -461,6 +379,7 @@ export function UserDetailScreen() {
                             moreDetails={moreDetails}
                             similarMovies={similarMovies}
                         />
+
                         <PlayerWrapper
                             data={data}
                             loading={loading}
@@ -477,17 +396,13 @@ export function UserDetailScreen() {
 function ExtraInfo(movieData) {
     return (
         <View
+            padding="$2"
+            mx="$4"
             style={{
-                marginHorizontal: 20,
+                fontWeight: 'bold',
             }}
         >
-            <XStack
-                flex={1}
-                style={{
-                    opacity: 0.8,
-                }}
-                alignSelf="center"
-            >
+            <XStack>
                 <>
                     <SizableText style={{ fontFamily: 'System' }}>
                         {movieData.release_date?.split('-')[0] ??
@@ -588,4 +503,51 @@ export async function getMetaAndPlay(
 ): Promise<BothMedia | null> {
     let res = await getMoviesMetadata(movieName, seriesOptions)
     return res === null ? null : res
+}
+
+const styles = StyleSheet.create({
+    gradient: {
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        bottom: 0,
+        padding: 40,
+        height: '90%',
+        justifyContent: 'flex-end',
+        alignItems: 'center',
+    },
+})
+
+const Badges = () => {
+    const BadgesUrl: Array<string> = [
+        'https://tv.apple.com/assets/badges/MetadataBadge%204K%20OnDark-c90195dae0171c69694b4d7386421ad8.svg',
+        'https://tv.apple.com/assets/badges/MetadataBadge%20AD%20OnDark-4731d380509cdd9c3e59e73cb9dc09d5.svg',
+        'https://tv.apple.com/assets/badges/MetadataBadge%20SDH%20OnDark-45f29ce5e07128bf67d924a31a003cf3.svg',
+        'https://tv.apple.com/assets/badges/MetadataBadge%20CC%20OnDark-7b5b00df263bfee5af843510f708c307.svg',
+    ]
+
+    return (
+        <XStack
+            flex={1}
+            space="$2"
+            borderWidth={2}
+            borderColor="transparent"
+            padding="$2"
+            mx="$4"
+            // alignSelf="center"
+        >
+            {BadgesUrl.map((item, index) => {
+                return (
+                    <YStack
+                        alignItems="center"
+                        padding="$0"
+                        backgroundColor="$transparent"
+                        theme={'alt2'}
+                    >
+                        <SvgUri uri={item} style={{ opacity: 0.8 }} />
+                    </YStack>
+                )
+            })}
+        </XStack>
+    )
 }

--- a/packages/app/hooks/useSeasonsAndEpisodes.ts
+++ b/packages/app/hooks/useSeasonsAndEpisodes.ts
@@ -6,13 +6,13 @@ import { getSeasonAndEpisodeDetails } from 'app/lib/movies/genre'
 export function useSeasonsAndEpisodes(
     movieType,
     seasonTmdbId,
-    seasonNumber?,
-    episodeNumber?
+    seasonNumber?: number,
+    episodeNumber?: number
 ) {
     if (movieType === 'movie') return null
     const [data, setData] = useState<SeasonAndEpisode | null>(null)
-    seasonNumber = seasonNumber ?? 1
-    episodeNumber = episodeNumber ?? 1
+    seasonNumber = seasonNumber || 1
+    episodeNumber = episodeNumber || 1
 
     useEffect(() => {
         const getSeasonsAndEpisodes = async () => {

--- a/packages/app/utils/index.ts
+++ b/packages/app/utils/index.ts
@@ -7,6 +7,31 @@ export function convertMinutesToHours(minutes: number) {
     return hours + 'h ' + remainingMinutes + 'm '
 }
 
+export const convertMilliSecToReadableTime = (duration: number) => {
+    const portions: string[] = []
+
+    const msInHour = 1000 * 60 * 60
+    const hours = Math.trunc(duration / msInHour)
+    if (hours > 0) {
+        portions.push(hours + 'h')
+        duration = duration - hours * msInHour
+    }
+
+    const msInMinute = 1000 * 60
+    const minutes = Math.trunc(duration / msInMinute)
+    if (minutes > 0) {
+        portions.push(minutes + 'm')
+        duration = duration - minutes * msInMinute
+    }
+
+    const seconds = Math.trunc(duration / 1000)
+    if (seconds > 0) {
+        portions.push(seconds + 's')
+    }
+
+    return portions.join(' ')
+}
+
 export const CannotPlayMovieDialog = () =>
     Alert.alert(
         'Cannot play movie',


### PR DESCRIPTION
This pull request introduces the following
- replace the `blurview` used in wrapping the movie logo with a `linear-gradient` which blends neatly with the app background colour.
- Adds a seasons selector for tv shows
- replace completion percentage with a read time format for viewing progress of shows and movies.
- readjust the details screen to be more user friendly.



|Moviee|Apple TV|
|-|-|
|![IMG_1231](https://github.com/ahmedsaheed/moviee/assets/87912847/ad5bf38b-8eb8-4097-bfb7-8c0f5a7d4cb1)|![IMG_1232](https://github.com/ahmedsaheed/moviee/assets/87912847/f84257eb-2ca9-49ed-95b0-907d0856eb9f)|


<sub>As seen in `Disney+` and `Apple TV` </sub>